### PR TITLE
Creating the NT service from the system drive

### DIFF
--- a/src/PatchOrchestrationApplication/NodeAgentService/src/InstallAndRunService.bat
+++ b/src/PatchOrchestrationApplication/NodeAgentService/src/InstallAndRunService.bat
@@ -1,7 +1,7 @@
 ﻿@echo off
 setlocal enabledelayedexpansion
 
-set rootDir=%~d0
+set rootDir=%SystemDrive%
 set currentDir=%cd%
 set applicationDir=%rootDir%\PatchOrchestrationApplication
 set workingDir=%applicationDir%\NodeAgentNTService


### PR DESCRIPTION
Creating the NT service from the system drive instead of the current drive, to fix NT service start issue when the temp drive is wiped out.