### PR TITLE
Resolving Warning MSB3276

### DIFF
--- a/src/properties/common.props
+++ b/src/properties/common.props
@@ -10,6 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     <NoWarn></NoWarn>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <ApplicationRoot>$(SrcRoot)\PatchOrchestrationApplication</ApplicationRoot>
     <OutputPath>$(ProjectDir)bin\$(Configuration)</OutputPath>
     <OUTPUTROOT>$(SrcRoot)\..\out</OUTPUTROOT>


### PR DESCRIPTION
Adding "AutoGenerateBindingRedirects" tag to be true in the props to resolve the warning MSB3276. 
![image](https://github.com/microsoft/Service-Fabric-POA/assets/47246856/0b03eb16-a9fe-4b58-b21c-49322ea115bb)
